### PR TITLE
add travis build icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Concurrent::Iterator
 
+[![Build Status](https://travis-ci.org/jnthn/p6-concurrent-iterator.svg?branch=master)](https://travis-ci.org/jnthn/p6-concurrent-iterator)
+
 A standard Perl 6 `Iterator` should only be consumed from one thread at a time.
 `Concurrent::Iterator` allows any Iterable to be iterated concurrently.
 


### PR DESCRIPTION
to show that either there wasn't a travis build yet (travis may need another commit to start running) or that someone forgot to add the repo to travis
